### PR TITLE
Setting this task to only work for EC2 because of several reasons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ECS Singleton Task
 
+**This module assumes an EC2 launch type.** For the complimentary fargate task, [go here.](https://github.com/7Factor/terraform-fargate-ecs-singleton-task)
+
 This module will allow you to deploy an ECS Task and an ECS Service. This is intended to be run as part of your app deployment
 pipeline. It works well with [Concourse.](https://concourse-ci.org) It is assumed you already have a solution for deploying an 
 ECS Cluster. If not, check out [ours.](https://github.com/7Factor/terraform-ecs-cluster).

--- a/ecs.tf
+++ b/ecs.tf
@@ -4,7 +4,7 @@ data "aws_ecs_cluster" "target_cluster" {
 
 resource "aws_ecs_task_definition" "main_task" {
   family                   = "${var.app_name}-tsk"
-  requires_compatibilities = [var.launch_type]
+  requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   cpu                      = var.cpu
   memory                   = var.memory
@@ -30,6 +30,6 @@ resource "aws_ecs_service" "main_service" {
   task_definition            = aws_ecs_task_definition.main_task.arn
   cluster                    = data.aws_ecs_cluster.target_cluster.id
   desired_count              = var.desired_task_count
-  launch_type                = var.launch_type
+  launch_type                = "EC2"
   deployment_maximum_percent = var.service_deployment_maximum_percent
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,14 +36,9 @@ variable "service_deployment_maximum_percent" {
   description = "The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment. Defaults to 200 percent, which should be used in 99% of cases to allow for proper green/blue."
 }
 
-variable "launch_type" {
-  default     = "EC2"
-  description = "The launch type for the task. We assume EC2 by default."
-}
-
 variable "volumes" {
   type        = list(any)
-  default     = []
+  default     = [{ name = "dev-null", host_path = "/dev/null" }]
   description = "A list of definitions to attach volumes to the ECS task. Amazon does not allow empty volume names once declared, so defaulting to a dummy name if this var is left unused."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,8 +37,8 @@ variable "service_deployment_maximum_percent" {
 }
 
 variable "volumes" {
-  type        = list(any)
-  default     = [{ name = "dev-null", host_path = "/dev/null" }]
+  type        = list(object({ name = string, host_path = string }))
+  default     = []
   description = "A list of definitions to attach volumes to the ECS task. Amazon does not allow empty volume names once declared, so defaulting to a dummy name if this var is left unused."
 }
 


### PR DESCRIPTION
The primary reason is because of the networking mode required to use Fargate. AWS VPC networking mode means we have to assign specific security groups to services and tasks instead of to the cluster itself, so we need the ability to pass this in. We could use dynamic blocks for this, but because dynamic blocks don't have a "don't add the block" fail state it would cause severe problems with EC2 mode that would require heinous hacks to get around.

So, instead, we just make a fargate specific copy of this task with fargat specific inputs and keep this guy nice and clean.