### PR TITLE
remove uneeded app_port argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **This module assumes an EC2 launch type.** For the complimentary fargate task, [go here.](https://github.com/7Factor/terraform-fargate-ecs-singleton-task)
 
 This module will allow you to deploy an ECS Task and an ECS Service. This is intended to be run as part of your app deployment
-pipeline. It works well with [Concourse.](https://concourse-ci.org) It is assumed you already have a solution for deploying an 
-ECS Cluster. If not, check out [ours.](https://github.com/7Factor/terraform-ecs-cluster).
+pipeline. It works well with [Concourse.](https://concourse-ci.org) It is assumed you already have a solution for deploying an
+ECS Cluster. If not, check out [ours](https://github.com/7Factor/terraform-ecs-cluster).
 
 This is a bare metal service implementation with no load balancers, target groups, and the like. If you want to deploy something
 with a load balancer you should check out our [HTTP](https://github.com/7Factor/terraform-ecs-http-task) task.
@@ -13,7 +13,7 @@ with a load balancer you should check out our [HTTP](https://github.com/7Factor/
 
 First, you need a decent understanding of how to use Terraform. [Hit the docs](https://www.terraform.io/intro/index.html) for that.
 Then, you should familiarize yourself with ECS [concepts](https://aws.amazon.com/ecs/getting-started/), especially if you've
-never worked with a clustering solution before. Once you're good, import this module and  pass the appropriate variables. 
+never worked with a clustering solution before. Once you're good, import this module and  pass the appropriate variables.
 Then, plan your run and deploy.
 
 ## Example Usage
@@ -24,7 +24,6 @@ module "terraform-ecs-task" {
   vpc_id                = "${data.aws_vpc.primary_vpc.id}"
 
   app_name              = "${var.app_name}"
-  app_port              = "${var.app_port}"
   cpu                   = "256"
   memory                = "256"
   desired_task_count    = "2"


### PR DESCRIPTION
The argument `app_port` does not seem to be used anywhere in this module. That makes sense if this is not exposing HTTP ports like the HTTP ECS module. 